### PR TITLE
Add unit tests for org.ice4j.ice.NetworkUtilsTest

### DIFF
--- a/src/test/java/org/ice4j/ice/NetworkUtilsTest.java
+++ b/src/test/java/org/ice4j/ice/NetworkUtilsTest.java
@@ -24,6 +24,36 @@ import org.junit.*;
 public class NetworkUtilsTest
 {
     @Test
+    public void testIpv4StringToBytes()
+    {
+        byte[] addr = NetworkUtils.strToIPv4("1");
+        assertArrayEquals(new byte[]{0, 0, 0, 1}, addr);
+
+        addr = NetworkUtils.strToIPv4("1.2");
+        assertArrayEquals(new byte[]{1, 0, 0, 2}, addr);
+
+        addr = NetworkUtils.strToIPv4("1.2.3");
+        assertArrayEquals(new byte[]{1, 2, 0, 3}, addr);
+
+        addr = NetworkUtils.strToIPv4("1.2.3.4");
+        assertArrayEquals(new byte[]{1, 2, 3, 4}, addr);
+
+        assertNull(NetworkUtils.strToIPv4(""));
+        assertNull(NetworkUtils.strToIPv4("-1"));
+        assertNull(NetworkUtils.strToIPv4("1.-2"));
+        assertNull(NetworkUtils.strToIPv4("-1.2"));
+        assertNull(NetworkUtils.strToIPv4("1.-2.3"));
+        assertNull(NetworkUtils.strToIPv4("1.2.-3"));
+        assertNull(NetworkUtils.strToIPv4("-1.2.3"));
+        assertNull(NetworkUtils.strToIPv4("1.-2.3.4"));
+        assertNull(NetworkUtils.strToIPv4("1.2.-3.4"));
+        assertNull(NetworkUtils.strToIPv4("1.2.3.-4"));
+        assertNull(NetworkUtils.strToIPv4("-1.2.3.4"));
+        assertNull(NetworkUtils.strToIPv4("1.2.3.4.5"));
+        assertNull(NetworkUtils.strToIPv4("1.2.3.256"));
+    }
+
+    @Test
     public void testIpv6StringToBytes()
     {
         byte[] addr = NetworkUtils.strToIPv6("::12");
@@ -42,6 +72,13 @@ public class NetworkUtilsTest
         assertNotNull(addr);
         assertEquals(18, addr[15]);
 
+        assertNull(NetworkUtils.strToIPv6(""));
+        assertNull(NetworkUtils.strToIPv6(":::"));
+        assertNull(NetworkUtils.strToIPv6("[^"));
+        assertNull(NetworkUtils.strToIPv6("[%"));
+        assertNull(NetworkUtils.strToIPv6(":?0"));
         assertNull(NetworkUtils.strToIPv6("[::12]%1"));
+        assertNull(NetworkUtils.strToIPv6("[::65536]%1"));
+        assertNull(NetworkUtils.strToIPv6("1111:222:3333:4444:5555:6666:7"));
     }
 }


### PR DESCRIPTION
Hi, I've analysed your codebase and seen some gaps in the coverage of:

org.ice4j.ice.NetworkUtilsTest

I've written tests with the help of [Diffblue Cover](https://www.diffblue.com/products) and increased line coverage for the following methods:
strToIPv4()
strToIPv6()
Total line coverage for the class, according to IntelliJ, is now 125/220 (56.8%); was 71/220 (32.3%) 
Hopefully, they will help you detect regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important.